### PR TITLE
Use Kube secrets to configure remote model endpoint, model name, and token

### DIFF
--- a/kubeflow-pipelines/docling-vlm/docling_convert_pipeline_compiled.yaml
+++ b/kubeflow-pipelines/docling-vlm/docling_convert_pipeline_compiled.yaml
@@ -4,10 +4,7 @@
 # Inputs:
 #    docling_image_export_mode: str [Default: 'embedded']
 #    docling_num_threads: int [Default: 4.0]
-#    docling_remote_model_api_key: str [Default: '']
 #    docling_remote_model_enabled: bool [Default: False]
-#    docling_remote_model_endpoint_url: str [Default: '']
-#    docling_remote_model_name: str [Default: '']
 #    docling_timeout_per_document: int [Default: 300.0]
 #    num_splits: int [Default: 3.0]
 #    pdf_base_url: str [Default: 'https://github.com/docling-project/docling/raw/v2.43.0/tests/data/pdf']
@@ -59,24 +56,14 @@ components:
         pdf_filenames:
           description: List of PDF file names to process.
           parameterType: LIST
-        remote_model_api_key:
-          defaultValue: ''
-          description: API key or token for the remote model.
-          isOptional: true
-          parameterType: STRING
         remote_model_enabled:
           defaultValue: false
           description: Whether or not to use a remote model.
           isOptional: true
           parameterType: BOOLEAN
-        remote_model_endpoint_url:
-          defaultValue: ''
-          description: URL of the remote model.
-          isOptional: true
-          parameterType: STRING
-        remote_model_name:
-          defaultValue: ''
-          description: Name of the remote model.
+        remote_model_secret_mount_path:
+          defaultValue: /mnt/secrets
+          description: Path to the remote model secret mount path.
           isOptional: true
           parameterType: STRING
         timeout_per_document:
@@ -122,14 +109,11 @@ components:
                 componentInputParameter: pipelinechannel--docling_num_threads
               pdf_filenames:
                 componentInputParameter: pipelinechannel--create-pdf-splits-Output-loop-item
-              remote_model_api_key:
-                componentInputParameter: pipelinechannel--docling_remote_model_api_key
               remote_model_enabled:
                 componentInputParameter: pipelinechannel--docling_remote_model_enabled
-              remote_model_endpoint_url:
-                componentInputParameter: pipelinechannel--docling_remote_model_endpoint_url
-              remote_model_name:
-                componentInputParameter: pipelinechannel--docling_remote_model_name
+              remote_model_secret_mount_path:
+                runtimeValue:
+                  constant: /mnt/secrets
               timeout_per_document:
                 componentInputParameter: pipelinechannel--docling_timeout_per_document
           taskInfo:
@@ -153,14 +137,8 @@ components:
           parameterType: STRING
         pipelinechannel--docling_num_threads:
           parameterType: NUMBER_INTEGER
-        pipelinechannel--docling_remote_model_api_key:
-          parameterType: STRING
         pipelinechannel--docling_remote_model_enabled:
           parameterType: BOOLEAN
-        pipelinechannel--docling_remote_model_endpoint_url:
-          parameterType: STRING
-        pipelinechannel--docling_remote_model_name:
-          parameterType: STRING
         pipelinechannel--docling_timeout_per_document:
           parameterType: NUMBER_INTEGER
   comp-import-pdfs:
@@ -258,21 +236,19 @@ deploymentSpec:
           \    artifacts_path: dsl.Input[dsl.Artifact],\n    output_path: dsl.Output[dsl.Artifact],\n\
           \    pdf_filenames: List[str],\n    num_threads: int = 4,\n    image_export_mode:\
           \ str = \"embedded\",\n    timeout_per_document: int = 300,\n    remote_model_enabled:\
-          \ bool = False,\n    remote_model_endpoint_url: str = \"\",\n    remote_model_api_key:\
-          \ str = \"\",\n    remote_model_name: str = \"\",\n):\n    \"\"\"\n    Convert\
-          \ a list of PDF files to JSON and Markdown using Docling.\n\n    Args:\n\
-          \        input_path: Path to the input directory containing PDF files.\n\
-          \        artifacts_path: Path to the directory containing Docling models.\n\
-          \        output_path: Path to the output directory for converted JSON and\
-          \ Markdown files.\n        pdf_filenames: List of PDF file names to process.\n\
-          \        pdf_backend: Backend to use for PDF processing.\n        image_export_mode:\
-          \ Mode to export images.\n        table_mode: Mode to detect tables.\n \
-          \       num_threads: Number of threads to use per document processing.\n\
-          \        timeout_per_document: Timeout per document processing.\n      \
-          \  remote_model_enabled: Whether or not to use a remote model.\n       \
-          \ remote_model_endpoint_url: URL of the remote model.\n        remote_model_api_key:\
-          \ API key or token for the remote model.\n        remote_model_name: Name\
-          \ of the remote model.\n    \"\"\"\n    import os\n    from importlib import\
+          \ bool = False,\n    remote_model_secret_mount_path: str = \"/mnt/secrets\"\
+          ,\n):\n    \"\"\"\n    Convert a list of PDF files to JSON and Markdown\
+          \ using Docling.\n\n    Args:\n        input_path: Path to the input directory\
+          \ containing PDF files.\n        artifacts_path: Path to the directory containing\
+          \ Docling models.\n        output_path: Path to the output directory for\
+          \ converted JSON and Markdown files.\n        pdf_filenames: List of PDF\
+          \ file names to process.\n        pdf_backend: Backend to use for PDF processing.\n\
+          \        image_export_mode: Mode to export images.\n        table_mode:\
+          \ Mode to detect tables.\n        num_threads: Number of threads to use\
+          \ per document processing.\n        timeout_per_document: Timeout per document\
+          \ processing.\n        remote_model_enabled: Whether or not to use a remote\
+          \ model.\n        remote_model_secret_mount_path: Path to the remote model\
+          \ secret mount path.\n    \"\"\"\n    import os\n    from importlib import\
           \ import_module\n    from pathlib import Path\n\n    from docling_core.types.doc.base\
           \ import ImageRefMode  # pylint: disable=import-outside-toplevel  # noqa:\
           \ PLC0415, E402\n    from docling.datamodel.base_models import InputFormat\
@@ -296,7 +272,28 @@ deploymentSpec:
           \ = {e.value for e in ImageRefMode}\n    if image_export_mode not in allowed_image_export_modes:\n\
           \        raise ValueError(\n            f\"Invalid image_export_mode: {image_export_mode}.\
           \ Must be one of {sorted(allowed_image_export_modes)}\"\n        )\n\n \
-          \   if remote_model_enabled:\n        if not remote_model_endpoint_url:\n\
+          \   if remote_model_enabled:\n        if not os.path.exists(remote_model_secret_mount_path):\n\
+          \            raise ValueError(f\"Secret for remote model should be mounted\
+          \ in {remote_model_secret_mount_path}\")\n\n        remote_model_endpoint_url_secret\
+          \ = \"REMOTE_MODEL_ENDPOINT_URL\"\n        remote_model_endpoint_url_file_path\
+          \ = os.path.join(remote_model_secret_mount_path, remote_model_endpoint_url_secret)\n\
+          \        if os.path.isfile(remote_model_endpoint_url_file_path):\n     \
+          \       with open(remote_model_endpoint_url_file_path) as f:\n         \
+          \       remote_model_endpoint_url = f.read()\n        else:\n          \
+          \  raise ValueError(f\"Key {remote_model_endpoint_url_secret} not defined\
+          \ in secret {remote_model_secret_mount_path}\")\n\n        remote_model_name_secret\
+          \ = \"REMOTE_MODEL_NAME\"\n        remote_model_name_file_path = os.path.join(remote_model_secret_mount_path,\
+          \ remote_model_name_secret)\n        if os.path.isfile(remote_model_name_file_path):\n\
+          \            with open(remote_model_name_file_path) as f:\n            \
+          \    remote_model_name = f.read()\n        else:\n            raise ValueError(f\"\
+          Key {remote_model_name_secret} not defined in secret {remote_model_secret_mount_path}\"\
+          )\n\n        remote_model_api_key_secret = \"REMOTE_MODEL_API_KEY\"\n  \
+          \      remote_model_api_key_file_path = os.path.join(remote_model_secret_mount_path,\
+          \ remote_model_api_key_secret)\n        if os.path.isfile(remote_model_api_key_file_path):\n\
+          \            with open(remote_model_api_key_file_path) as f:\n         \
+          \       remote_model_api_key = f.read()\n        else:\n            raise\
+          \ ValueError(f\"Key {remote_model_api_key_secret} not defined in secret\
+          \ {remote_model_secret_mount_path}\")\n\n        if not remote_model_endpoint_url:\n\
           \            raise ValueError(\"remote_model_endpoint_url must be provided\
           \ when remote_model_enabled is True\")\n\n        pipeline_options = VlmPipelineOptions(\n\
           \            enable_remote_services=True,\n        )\n        pipeline_options.vlm_options\
@@ -304,10 +301,8 @@ deploymentSpec:
           \            params=dict(\n                model_id=remote_model_name,\n\
           \                parameters=dict(\n                    max_new_tokens=400,\n\
           \                ),\n            ),\n            prompt=\"OCR the full page\
-          \ to markdown.\",\n            timeout=360,\n            response_format=ResponseFormat.MARKDOWN,\n\
-          \            # TODO: remote_model_api_key should be something other than\
-          \ a KFP param (maybe a secret?), so it's not exposed in the UI\n       \
-          \     headers={\n                \"Authorization\": f\"Bearer {remote_model_api_key}\"\
+          \ to markdown.\",\n            timeout=600,\n            response_format=ResponseFormat.MARKDOWN,\n\
+          \            headers={\n                \"Authorization\": f\"Bearer {remote_model_api_key}\"\
           ,\n            },\n        )\n    else:\n        pipeline_options = VlmPipelineOptions()\n\
           \n    pipeline_cls = VlmPipeline\n    pipeline_options.artifacts_path =\
           \ artifacts_path_p\n    pipeline_options.document_timeout = float(timeout_per_document)\n\
@@ -539,14 +534,8 @@ root:
               componentInputParameter: docling_image_export_mode
             pipelinechannel--docling_num_threads:
               componentInputParameter: docling_num_threads
-            pipelinechannel--docling_remote_model_api_key:
-              componentInputParameter: docling_remote_model_api_key
             pipelinechannel--docling_remote_model_enabled:
               componentInputParameter: docling_remote_model_enabled
-            pipelinechannel--docling_remote_model_endpoint_url:
-              componentInputParameter: docling_remote_model_endpoint_url
-            pipelinechannel--docling_remote_model_name:
-              componentInputParameter: docling_remote_model_name
             pipelinechannel--docling_timeout_per_document:
               componentInputParameter: docling_timeout_per_document
         parameterIterator:
@@ -582,22 +571,10 @@ root:
         defaultValue: 4.0
         isOptional: true
         parameterType: NUMBER_INTEGER
-      docling_remote_model_api_key:
-        defaultValue: ''
-        isOptional: true
-        parameterType: STRING
       docling_remote_model_enabled:
         defaultValue: false
         isOptional: true
         parameterType: BOOLEAN
-      docling_remote_model_endpoint_url:
-        defaultValue: ''
-        isOptional: true
-        parameterType: STRING
-      docling_remote_model_name:
-        defaultValue: ''
-        isOptional: true
-        parameterType: STRING
       docling_timeout_per_document:
         defaultValue: 300.0
         isOptional: true
@@ -625,6 +602,14 @@ platforms:
   kubernetes:
     deploymentSpec:
       executors:
+        exec-docling-convert:
+          secretAsVolume:
+          - mountPath: /mnt/secrets
+            optional: true
+            secretName: data-processing-docling-pipeline
+            secretNameParameter:
+              runtimeValue:
+                constant: data-processing-docling-pipeline
         exec-import-pdfs:
           secretAsVolume:
           - mountPath: /mnt/secrets


### PR DESCRIPTION
[RHAIENG-527](https://issues.redhat.com/browse/RHAIENG-527)

## Description
Switch remote VLM model to use Kube secrets rather than KFP params for the endpoint, model name, and token configs. 

If  `docling_remote_model_enabled = True`, the pipeline will search for a secret named `data-processing-docling-pipeline` in the same namespace. Then, it will use the following secret values to configure the connection to the remote model API: `REMOTE_MODEL_ENDPOINT_URL`, `REMOTE_MODEL_API_KEY`, and `REMOTE_MODEL_NAME`.

## How Has This Been Tested?

Tested on OpenShift AI cluster and a granite-vision-3-2 model running remotely on a https://github.com/rh-aiservices-bu/models-aas server.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Remote model now configured via a single secret mount path, automatically loading endpoint, model name, and API key from the mounted secret.

- Improvements
  - Simplified pipeline parameters by replacing three credential inputs with one secret path.
  - Increased remote model request timeout from 360 to 600 seconds.
  - Added pre-run validation with clearer errors for missing secrets or empty endpoint values.

- Documentation
  - Updated usage guidance to reflect secret-based configuration and revised parameter descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->