### PR TITLE
update CODEOWNERS to reference team instead of ind

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
-# Each line is a file pattern followed by one or more owners.
+# Default owners for everything
+*  @opendatahub-io/odh-data-processing
 
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-* @alimaredia @fabianofranz @franciscojavierarceo @alinaryan @roburishabh
+# Keep the CODEOWNERS file itself owned by the team
+/.github/CODEOWNERS  @opendatahub-io/odh-data-processing


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This change updates the CODEOWNERS file to reference a team instead of individual users.
With this setup, a single approval from any team member will satisfy the code owner requirement, allowing PRs to be merged without requiring approval from all listed individuals.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository ownership rules: all files now default to ownership by @opendatahub-io/odh-data-processing, with the CODEOWNERS file explicitly owned by the same team. This standardizes ownership across the codebase.
* **Notes**
  * No user-facing changes. Application features, behavior, and UI remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->