### PR TITLE
Fixes links to YAML pipelines in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ odh-data-processing
 
 ### Kubeflow Pipelines
 
-Refer to the [ODH Data Processing Kubeflow Pipelines](kubeflow-pipelines/README.md) documentation for instructions on how to install, run, and customize the [Standard](kubeflow-pipelines/docling-standard/README.md) and [VLM](kubeflow-pipelines/docling-vlm/README.md) pipelines.
+Refer to the [ODH Data Processing Kubeflow Pipelines](kubeflow-pipelines) documentation for instructions on how to install, run, and customize the [Standard](kubeflow-pipelines/docling-standard) and [VLM](kubeflow-pipelines/docling-vlm) pipelines.
 
 ## 🤝 Contributing
 

--- a/kubeflow-pipelines/README.md
+++ b/kubeflow-pipelines/README.md
@@ -56,22 +56,22 @@ Start by importing the compiled YAML file for the desired Docling pipeline (stan
 
 **For the Standard Pipeline**: 
 
-Download the [compiled YAML file](docling-standard/docling_convert_pipeline_compiled.yaml?raw=1) and upload it on the _Import pipeline_ screen, or import it by URL by pointing it to `https://raw.githubusercontent.com/opendatahub-io/odh-data-processing/refs/heads/main/kubeflow-pipelines/docling-standard/docling_convert_pipeline_compiled.yaml`.
+Download the [compiled YAML file](docling-standard/standard_convert_pipeline_compiled.yaml?raw=1) and upload it on the _Import pipeline_ screen, or import it by URL by pointing it to `https://github.com/opendatahub-io/odh-data-processing/raw/refs/heads/main/kubeflow-pipelines/docling-standard/standard_convert_pipeline_compiled.yaml`.
 
 **For the VLM Pipeline**: 
 
-Download the [compiled YAML file](docling-vlm/docling_convert_pipeline_compiled.yaml?raw=1) and upload it on the _Import pipeline_ screen, or import it by URL by pointing it to `https://raw.githubusercontent.com/opendatahub-io/odh-data-processing/refs/heads/main/kubeflow-pipelines/docling-vlm/docling_convert_pipeline_compiled.yaml`.
+Download the [compiled YAML file](docling-vlm/vlm_convert_pipeline_compiled.yaml?raw=1) and upload it on the _Import pipeline_ screen, or import it by URL by pointing it to `https://github.com/opendatahub-io/odh-data-processing/raw/refs/heads/main/kubeflow-pipelines/docling-vlm/vlm_convert_pipeline_compiled.yaml`.
 
 Optionally, compile from source to generate the pipeline YAML yourself:
 
 ```bash
 # Standard pipeline
 cd odh-data-processing/kubeflow-pipelines/docling-standard
-python docling_convert_pipeline.py
+python standard_convert_pipeline.py
 
 # VLM pipeline
 cd odh-data-processing/kubeflow-pipelines/docling-vlm
-python docling_convert_pipeline.py
+python vlm_convert_pipeline.py
 ```
 
 ## 🖥️ Running
@@ -84,8 +84,8 @@ Once conversion finishes, the converted documents are stored in two output forma
 
 Both standard and VLM pipelines provide default conversion options that should be a good starting point for most document conversions. For more advanced conversion options, both pipelines expose a set of **runtime parameters** that can be changed to tweak the conversion strategy used by Docling:
 
-- [docling-standard configuration options](docling-standard/README.md)
-- [docling-vlm configuration options](docling-vlm/README.md) 
+- [docling-standard configuration options](docling-standard)
+- [docling-vlm configuration options](docling-vlm) 
 
 By default, both pipelines will consume documents stored in an HTTP/S source. To configure the source of the documents you'd like to convert, set the `pdf_base_url` and the `pdf_filenames` (comma-separated list of the file names) parameters. The default values of these parameters point to a sample set of PDFs frequently used to test Docling conversions.
 
@@ -162,6 +162,6 @@ Toggle enrichments via boolean parameters:
 
 - Increase `num_splits` to **parallelize** across more workers (uses KFP `ParallelFor`).
 - Tune `num_threads` and `timeout_per_document`.
-- Adjust **container resources** per component, e.g. `set_memory_limit("6G")`, `set_cpu_limit("4")`, in [`docling-standard/docling_convert_pipeline.py`](docling-standard/docling_convert_pipeline.py) or [`docling-vlm/docling_convert_pipeline.py`](docling-vlm/docling_convert_pipeline.py).
-- Change the value of the `base_image` component parameter ([example](https://github.com/opendatahub-io/odh-data-processing/blob/ceeb8be59910ea2986f33ee4c717ce31be66f1f5/kubeflow-pipelines/docling-standard/docling_convert_components.py#L176)) if you'd like to set a **custom container image** to be used in the pipeline run.
+- Adjust **container resources** per component, e.g. `set_memory_limit("6G")`, `set_cpu_limit("4")`, in [`docling-standard/standard_convert_pipeline.py`](docling-standard/standard_convert_pipeline.py) or [`docling-vlm/vlm_convert_pipeline.py`](docling-vlm/vlm_convert_pipeline.py).
+- Change the value of the `base_image` component parameter ([example](https://github.com/opendatahub-io/odh-data-processing/blob/2bc017c30f862a11fc12c0551c31e8cc93ea6e51/kubeflow-pipelines/docling-standard/standard_components.py#L12)) if you'd like to set a **custom container image** to be used in the pipeline run.
 - Recompile the pipeline YAML after code or parameter interface changes to refresh the compiled YAML.

--- a/kubeflow-pipelines/docling-standard/README.md
+++ b/kubeflow-pipelines/docling-standard/README.md
@@ -4,7 +4,7 @@ Standard (non-VLM) Docling [Kubeflow Pipeline](https://www.kubeflow.org/docs/com
 
 ## Installation
 
-Download the [compiled YAML file](docling_convert_pipeline_compiled.yaml?raw=1) and upload it on the _Import pipeline_ screen, or import it by URL by pointing it to `https://raw.githubusercontent.com/opendatahub-io/odh-data-processing/refs/heads/main/kubeflow-pipelines/docling-standard/docling_convert_pipeline_compiled.yaml`.
+Download the [compiled YAML file](standard_convert_pipeline_compiled.yaml?raw=1) and upload it on the _Import pipeline_ screen, or import it by URL by pointing it to `https://github.com/opendatahub-io/odh-data-processing/raw/refs/heads/main/kubeflow-pipelines/docling-standard/standard_convert_pipeline_compiled.yaml`.
 
 ## Configuration options
 
@@ -41,9 +41,9 @@ pip install -r requirements.txt
 
 ### Compile the kubeflow pipeline
 
-This generates `docling_convert_pipeline_compiled.yaml`:
+This generates `standard_convert_pipeline_compiled.yaml`:
 
 ```bash
-python docling_convert_pipeline.py
+python standard_convert_pipeline.py
 ```
 

--- a/kubeflow-pipelines/docling-vlm/README.md
+++ b/kubeflow-pipelines/docling-vlm/README.md
@@ -4,7 +4,7 @@ Vision-Language-Model (VLM) Docling [Kubeflow Pipeline](https://www.kubeflow.org
 
 ## Installation
 
-Download the [compiled YAML file](docling_convert_pipeline_compiled.yaml?raw=1) and upload it on the _Import pipeline_ screen, or import it by URL by pointing it to `https://raw.githubusercontent.com/opendatahub-io/odh-data-processing/refs/heads/main/kubeflow-pipelines/docling-vlm/docling_convert_pipeline_compiled.yaml`.
+Download the [compiled YAML file](vlm_convert_pipeline_compiled.yaml?raw=1) and upload it on the _Import pipeline_ screen, or import it by URL by pointing it to `https://github.com/opendatahub-io/odh-data-processing/raw/refs/heads/main/kubeflow-pipelines/docling-vlm/vlm_convert_pipeline_compiled.yaml`.
 
 ## Configuration options
 
@@ -33,9 +33,9 @@ pip install -r requirements.txt
 
 ### Compile the kubeflow pipeline
 
-This generates `docling_convert_pipeline_compiled.yaml`:
+This generates `vlm_convert_pipeline_compiled.yaml`:
 
 ```bash
-python docling_convert_pipeline.py
+python vlm_convert_pipeline.py
 ```
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes links and URL's of the compiled YAML pipelines that changed after the [refactoring](https://github.com/opendatahub-io/odh-data-processing/pull/12).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Kubeflow Pipelines guides to use standardized naming for Standard and VLM pipelines (replaced docling_* names with standard_* and vlm_*).
  * Revised import, build, and compile instructions to match new script and compiled YAML names and locations.
  * Replaced file-specific README links with directory-level links and corrected raw asset URLs.
  * Updated component/resource example paths and improved narrative clarity and cross-links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->